### PR TITLE
Fix URL to variables list

### DIFF
--- a/includes/commands/_introduction.md
+++ b/includes/commands/_introduction.md
@@ -36,7 +36,7 @@ The commands endpoints allow you to view, add, edit, and remove channel commands
 		<tr>
 			<td><code>message</code></td>
 			<td>string</td>
-			<td>The message Nightbot sends to chat when the command is called. It can contain <a href="https://docs.nightbot.tv/commands/variables" target="_blank">variables</a> for extra functionality.</td>
+			<td>The message Nightbot sends to chat when the command is called. It can contain <a href="https://docs.nightbot.tv/commands/variableslist" target="_blank">variables</a> for extra functionality.</td>
 		</tr>
 		<tr>
 			<td><code>name</code></td>

--- a/includes/commands/_post.md
+++ b/includes/commands/_post.md
@@ -57,7 +57,7 @@ The following parameters can be sent as a URL encoded string or JSON (using the 
 			<td>message</td>
 			<td>string</td>
 			<td>Required</td>
-			<td>The message to send to chat. It can contain <a href="https://docs.nightbot.tv/commands/variables" target="_blank">variables</a> for extra functionality. Maximum length: 400 characters</td>
+			<td>The message to send to chat. It can contain <a href="https://docs.nightbot.tv/commands/variableslist" target="_blank">variables</a> for extra functionality. Maximum length: 400 characters</td>
 		</tr>
 		<tr>
 			<td>name</td>

--- a/includes/commands/_put_id.md
+++ b/includes/commands/_put_id.md
@@ -60,7 +60,7 @@ The following parameters can be sent as a URL encoded string or JSON (using the 
 			<td>message</td>
 			<td>string</td>
 			<td>Optional</td>
-			<td>The message to send to chat. It can contain <a href="https://docs.nightbot.tv/commands/variables" target="_blank">variables</a> for extra functionality. Maximum length: 400 characters</td>
+			<td>The message to send to chat. It can contain <a href="https://docs.nightbot.tv/commands/variableslist" target="_blank">variables</a> for extra functionality. Maximum length: 400 characters</td>
 		</tr>
 		<tr>
 			<td>name</td>

--- a/includes/timers/_introduction.md
+++ b/includes/timers/_introduction.md
@@ -41,7 +41,7 @@ The timers endpoints allow you to view, add, edit, and remove channel timers.
 		<tr>
 			<td><code>message</code></td>
 			<td>string</td>
-			<td>The message Nightbot sends to chat when the command is called. It can contain <a href="https://docs.nightbot.tv/commands/variables" target="_blank">variables</a> for extra functionality.</td>
+			<td>The message Nightbot sends to chat when the command is called. It can contain <a href="https://docs.nightbot.tv/commands/variableslist" target="_blank">variables</a> for extra functionality.</td>
 		</tr>
 		<tr>
 			<td><code>name</code></td>

--- a/includes/timers/_post.md
+++ b/includes/timers/_post.md
@@ -70,7 +70,7 @@ The following parameters can be sent as a URL encoded string or JSON (using the 
 			<td>message</td>
 			<td>string</td>
 			<td>Required</td>
-			<td>The message to send to chat. It can contain <a href="https://docs.nightbot.tv/commands/variables" target="_blank">variables</a> for extra functionality. Maximum length: 400 characters</td>
+			<td>The message to send to chat. It can contain <a href="https://docs.nightbot.tv/commands/variableslist" target="_blank">variables</a> for extra functionality. Maximum length: 400 characters</td>
 		</tr>
 		<tr>
 			<td>name</td>

--- a/includes/timers/_put_id.md
+++ b/includes/timers/_put_id.md
@@ -67,7 +67,7 @@ The following parameters can be sent as a URL encoded string or JSON (using the 
 			<td>message</td>
 			<td>string</td>
 			<td>Optional</td>
-			<td>The message to send to chat. It can contain <a href="https://docs.nightbot.tv/commands/variables" target="_blank">variables</a> for extra functionality. Maximum length: 400 characters</td>
+			<td>The message to send to chat. It can contain <a href="https://docs.nightbot.tv/commands/variableslist" target="_blank">variables</a> for extra functionality. Maximum length: 400 characters</td>
 		</tr>
 		<tr>
 			<td>name</td>


### PR DESCRIPTION
Links to https://docs.nightbot.tv/commands/variables are currently 404, took a guess at the updated link.